### PR TITLE
Include make in the Docker image for Ruby dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM udacity/ruby:2.2.4
+RUN apk-install make
 RUN bundle install --jobs 20 --retry 5 --without development test
 ADD .
 CMD ["fomotograph.rb"]


### PR DESCRIPTION
Should unbreak this part of the build: https://circleci.com/gh/udacity/fomotograph-api/15