### PR TITLE
Include gcc in the Docker image for building Ruby dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM udacity/ruby:2.2.4
-RUN apk-install make
+RUN apk-install make gcc musl-dev
 RUN bundle install --jobs 20 --retry 5 --without development test
 ADD .
 CMD ["fomotograph.rb"]


### PR DESCRIPTION
This should fix the gcc error in https://circleci.com/gh/udacity/fomotograph-api/18